### PR TITLE
feat: add ctrl shortcuts for Windows/Linux

### DIFF
--- a/app/components/SearchBar.tsx
+++ b/app/components/SearchBar.tsx
@@ -16,7 +16,7 @@ export function SearchBar() {
   const searchApi = useJsonSearchApi();
 
   useHotkeys(
-    "cmd+k",
+    "cmd+k,ctrl+k",
     (e) => {
       e.preventDefault();
       setIsOpen(true);

--- a/app/components/SideBar.tsx
+++ b/app/components/SideBar.tsx
@@ -14,7 +14,7 @@ export function SideBar() {
   return (
     <div className="side-bar flex flex-col align-center justify-between h-full p-1 bg-slate-200 transition dark:bg-slate-800">
       <ol className="relative">
-        <SidebarLink to={`/j/${doc.id}`} hotKey="cmd+1">
+        <SidebarLink to={`/j/${doc.id}`} hotKey="cmd+1,ctrl+1">
           <ToolTip arrow="left">
             <Body>Column view</Body>
             <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">
@@ -26,7 +26,7 @@ export function SideBar() {
           </ToolTip>
           <TemplateIcon className="p-2 w-full h-full" />
         </SidebarLink>
-        <SidebarLink to={`/j/${doc.id}/editor`} hotKey="cmd+2">
+        <SidebarLink to={`/j/${doc.id}/editor`} hotKey="cmd+2,ctrl+2">
           <ToolTip arrow="left">
             <Body>JSON view</Body>
             <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">
@@ -38,7 +38,7 @@ export function SideBar() {
           </ToolTip>
           <CodeIcon className="p-2 w-full h-full" />
         </SidebarLink>
-        <SidebarLink to={`/j/${doc.id}/tree`} hotKey="cmd+3">
+        <SidebarLink to={`/j/${doc.id}/tree`} hotKey="cmd+3,ctrl+3">
           <ToolTip arrow="left">
             <Body>Tree view</Body>
             <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">
@@ -52,7 +52,7 @@ export function SideBar() {
         </SidebarLink>
       </ol>
       <ol>
-        <SidebarLink to={`/j/${doc.id}/terminal`} hotKey="cmd+4">
+        <SidebarLink to={`/j/${doc.id}/terminal`} hotKey="cmd+4,ctrl+4">
           <ToolTip arrow="left">
             <Body>Terminal</Body>
             <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">


### PR DESCRIPTION
- add ctrl alternative for cmd shortcuts (cmd turns out to be the `windows` key in Windows/Linux and most of the time `ctrl` is used instead in these OSs)