### PR TITLE
Infer XML string from homepage's input box and convert to JSON

### DIFF
--- a/app/jsonDoc.server.ts
+++ b/app/jsonDoc.server.ts
@@ -1,5 +1,7 @@
 import { customRandom } from "nanoid";
 import safeFetch from "./utilities/safeFetch";
+import createFromRawXml from "./utilities/xml/createFromRawXml";
+import isXML from "./utilities/xml/isXML";
 
 type BaseJsonDocument = {
   id: string;
@@ -36,6 +38,12 @@ export async function createFromUrlOrRawJson(
 
   if (isJSON(urlOrJson)) {
     return createFromRawJson("Untitled", urlOrJson);
+  }
+
+  // Wrapper for createFromRawJson to handle XML
+  // TODO ? change from urlOrJson to urlOrJsonOrXml 
+  if (isXML(urlOrJson)) {
+    return createFromRawXml("Untitled", urlOrJson);
   }
 }
 

--- a/app/theme.server.ts
+++ b/app/theme.server.ts
@@ -2,7 +2,7 @@ import { createCookieSessionStorage } from "remix";
 
 import { Theme, isTheme } from "~/components/ThemeProvider";
 
-const sessionSecret = 'SESSION_SECRET';
+const sessionSecret = SESSION_SECRET;
 
 // if (!sessionSecret) {
 //   throw new Error("SESSION_SECRET must be set");

--- a/app/theme.server.ts
+++ b/app/theme.server.ts
@@ -2,7 +2,7 @@ import { createCookieSessionStorage } from "remix";
 
 import { Theme, isTheme } from "~/components/ThemeProvider";
 
-const sessionSecret = SESSION_SECRET;
+const sessionSecret = 'SESSION_SECRET';
 
 // if (!sessionSecret) {
 //   throw new Error("SESSION_SECRET must be set");

--- a/app/utilities/xml/__test__/convertXmlToJsonString.test.ts
+++ b/app/utilities/xml/__test__/convertXmlToJsonString.test.ts
@@ -1,0 +1,23 @@
+import * as fs from "fs";
+import { join } from "path";
+import convertFromRawXml from "../convertFromRawXml";
+
+const xmlString = fs.readFileSync(join(__dirname, "./xml.txt"), "utf8");
+
+describe("convertFromRawXml", () => {
+  test("Returns a string", () => {
+    expect(typeof convertFromRawXml("<xml></xml>")).toBe("string");
+    expect(typeof convertFromRawXml(xmlString)).toBe("string");
+  });
+
+  test("Returns a string that is valid JSON string", () => {
+    expect(() => JSON.parse(convertFromRawXml("<xml></xml>"))).not.toThrow();
+    expect(() => JSON.parse(convertFromRawXml(xmlString))).not.toThrow();
+  });
+
+  test("Throw error if invalid XML", () => {
+    expect(() => convertFromRawXml("<xml></xml")).toThrow();
+    expect(() => convertFromRawXml("")).toThrow();
+    expect(() => convertFromRawXml("lol")).toThrow();
+  });
+});

--- a/app/utilities/xml/__test__/isXML.test.ts
+++ b/app/utilities/xml/__test__/isXML.test.ts
@@ -1,0 +1,18 @@
+import * as fs from "fs";
+import { join } from "path";
+import isXML from "../isXML";
+
+const xmlString = fs.readFileSync(join(__dirname, "./xml.txt"), "utf8");
+
+describe("isXML", () => {
+  test("returns true for valid XML", () => {
+    expect(isXML("<xml></xml>")).toBe(true);
+    expect(isXML("<whatever>Content</whatever>")).toBe(true);
+    expect(isXML(xmlString)).toBe(true);
+  });
+  test("returns false for invalid XML", () => {
+    expect(isXML("<xml></xml")).toBe(false);
+    expect(isXML("lol")).toBe(false);
+    expect(isXML("")).toBe(false);
+  });
+});

--- a/app/utilities/xml/__test__/xml.txt
+++ b/app/utilities/xml/__test__/xml.txt
@@ -1,0 +1,56 @@
+<!-- <?xml version = "1.0"?>
+<!DOCTYPE ORDERFILE [
+<!ELEMENT ORDERFILE (CUSTOMER)*>
+<!ELEMENT CUSTOMER (NAME, DATE, ORDERS)>
+<!ELEMENT NAME (LAST-NAME, FIRST-NAME)>
+<!ELEMENT LAST-NAME (#PCDATA)>
+<!ELEMENT FIRST-NAME (#PCDATA)>
+<!ELEMENT DATE (#PCDATA)>
+<!ELEMENT ORDERS (ITEM)*>
+<!ELEMENT ITEM (PRODUCT, NUMBER, (PRICE | CHARGEACCT | SAMPLE))>
+<!ELEMENT PRODUCT (#PCDATA)>
+<!ELEMENT NUMBER (#PCDATA)>
+<!ELEMENT PRICE (#PCDATA)>
+<!ELEMENT CHARGEACCT (#PCDATA)>
+<!ELEMENT SAMPLE (#PCDATA)>
+]> -->
+<ORDERFILE>
+  <CUSTOMER>
+    <NAME gender="female">
+      <LAST-NAME>Smith</LAST-NAME>
+      <FIRST-NAME>Sam</FIRST-NAME>
+    </NAME>
+    <DATE>October 15, 2001</DATE>
+    <ORDERS>
+      <ITEM>
+        <PRODUCT>Tomatoes</PRODUCT>
+        <NUMBER>8</NUMBER>
+        <PRICE>1.25</PRICE>
+      </ITEM>
+      <ITEM>
+        <PRODUCT>Apples</PRODUCT>
+        <NUMBER>12</NUMBER>
+        <PRICE>2.50</PRICE>
+      </ITEM>
+      <ITEM>
+        <PRODUCT>Bananas</PRODUCT>
+        <NUMBER>6</NUMBER>
+        <PRICE>.50</PRICE>
+      </ITEM>
+    </ORDERS>
+  </CUSTOMER>
+  <CUSTOMER gender="male">
+    <NAME>
+      <LAST-NAME>Snead</LAST-NAME>
+      <FIRST-NAME>Todd</FIRST-NAME>
+    </NAME>
+    <DATE>October 17, 2001</DATE>
+    <ORDERS>
+      <ITEM>
+        <PRODUCT>Slicer/Dicer</PRODUCT>
+        <NUMBER>1</NUMBER>
+        <CHARGEACCT>1234-5678-3456-7890</CHARGEACCT>
+      </ITEM>
+    </ORDERS>
+  </CUSTOMER>
+</ORDERFILE>

--- a/app/utilities/xml/convertFromRawXml.ts
+++ b/app/utilities/xml/convertFromRawXml.ts
@@ -1,0 +1,112 @@
+import { DOMParser } from "xmldom";
+
+export type SerializedXMLObject = {
+  [key: string]: [] | string | {} | undefined;
+  $attributes?: { [key: string]: any };
+  $values?: [] | { [key: string]: any };
+};
+
+const getCleanXmlString = (xmlString: string): string => {
+  const cleanXmlString = xmlString
+    .replace(/(\r\n|\n|\r)/gm, "") // remove line breaks
+    .replace(/>\s+</g, "><"); // remove all whitespaces between tags
+  return cleanXmlString;
+};
+
+const serializeXml = (
+  node: ChildNode & { attributes?: NamedNodeMap }
+): SerializedXMLObject | string | undefined => {
+  const { nodeName, nodeType, nodeValue } = node;
+
+  // text
+  if (nodeType === 3) {
+    return nodeValue || undefined;
+  }
+
+  // comment, ignore
+  if (nodeType === 8) {
+    return undefined;
+  }
+
+  const children = Array.from(node.childNodes).map((child) =>
+    serializeXml(child)
+  );
+
+  const attributes =
+    node.attributes &&
+    Array.from(node.attributes).reduce(
+      (acc: {}, attr: any) => ({ ...acc, [attr.name]: attr.value }),
+      {}
+    );
+
+  let childObject: any = {};
+
+  if (children.length === 1 && typeof children[0] === "string") {
+    childObject[nodeName] = children[0];
+  } else {
+    childObject[nodeName] = {};
+
+    // childenUniqueKeys check if children should be processed as array
+    // or should be added as properties of parent object.
+    // e.g: In [{ name: 'foo' }, { name: 'bar' }],
+    // children bear the same "name" key, so parent object will look like:
+    //
+    // parent: {
+    //   $values: [
+    //     { name: 'foo' },
+    //     { name: 'bar' }
+    //   ],
+    //   $attributes: { ... }
+    // }
+    //
+    // In [{ name: 'foo' }, { age: 10 }],
+    // children have different keys and will be merged into parent object:
+    // parent: { name: 'foo', age: 10 }
+    const childenUniqueKeys = new Set(
+      children.map((child: any) => Object.keys(child)[0])
+    );
+
+    if (childenUniqueKeys.size === children.length) {
+      childObject[nodeName] = children.reduce(
+        (acc: {}, child: any) => ({ ...acc, ...child }),
+        {}
+      );
+    } else {
+      childObject[nodeName].$values = children;
+    }
+  }
+
+  if (attributes && Object.keys(attributes).length) {
+    childObject[nodeName].$attributes = attributes;
+  }
+
+  return childObject;
+};
+
+export default function convertFromRawXml(xmlString: string): string {
+  const cleanXmlString = getCleanXmlString(xmlString);
+
+  // Read comment in isXML.ts for why we need to handle error this way
+  const xmlDoc = new DOMParser({
+    errorHandler: {
+      warning: () => {},
+      error: () => {
+        throw new Error("Invalid XML");
+      },
+      fatalError: () => {
+        throw new Error("Invalid XML");
+      },
+    },
+  }).parseFromString(cleanXmlString, "application/xml");
+
+  // This line is necessary because xmldom does not throw an error
+  // if we pass it a plain string.
+  if (!xmlDoc?.documentElement) throw new Error("Invalid XML");
+
+  const nodes = Array.from(xmlDoc.childNodes);
+  const serialized = nodes.map((node) => {
+    return serializeXml(node);
+  });
+
+  return JSON.stringify(serialized);
+}

--- a/app/utilities/xml/createFromRawXml.ts
+++ b/app/utilities/xml/createFromRawXml.ts
@@ -1,0 +1,15 @@
+import {
+  createFromRawJson,
+  CreateJsonOptions,
+  JSONDocument,
+} from "~/jsonDoc.server";
+import convertFromRawXml from "./convertFromRawXml";
+
+export default async function createFromRawXml(
+  filename: string,
+  contents: string,
+  options?: CreateJsonOptions
+): Promise<JSONDocument> {
+  const jsonString: string = convertFromRawXml(contents);
+  return createFromRawJson(filename, jsonString, options);
+}

--- a/app/utilities/xml/isXML.ts
+++ b/app/utilities/xml/isXML.ts
@@ -1,0 +1,29 @@
+import { DOMParser } from "xmldom";
+
+export default function isXML(possibleXml: string): boolean {
+  let isValid = true;
+
+  // https://www.npmjs.com/package/xmldom
+  // xmldom handles invalid XML gracefully, so we need to check for errors
+  // in this way, rather than relying on the return value of parseFromString
+  // as recommended in this documentation::
+  // https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#error_handling
+
+  const xmlDoc = new DOMParser({
+    errorHandler: {
+      warning: () => {},
+      error: () => {
+        isValid = false;
+      },
+      fatalError: () => {
+        isValid = false;
+      },
+    },
+  }).parseFromString(possibleXml, "application/xml");
+
+  // This line is necessary because xmldom does not throw an error
+  // if we pass it a plain string.
+  if (!xmlDoc?.documentElement) isValid = false;
+
+  return isValid;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,8 @@
         "remix": "^1.2.3",
         "tailwindcss-radix": "^1.6.0",
         "tiny-invariant": "^1.2.0",
-        "ts-pattern": "^3.3.4"
+        "ts-pattern": "^3.3.4",
+        "xmldom": "^0.6.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^2.2.2",
@@ -54,6 +55,7 @@
         "@types/react": "^17.0.24",
         "@types/react-dom": "^17.0.9",
         "@types/ua-parser-js": "^0.7.36",
+        "@types/xmldom": "^0.1.31",
         "concurrently": "^7.0.0",
         "esbuild-visualizer": "^0.3.1",
         "jest": "^27.4.7",
@@ -3061,6 +3063,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "dev": true
+    },
+    "node_modules/@types/xmldom": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha512-bVy7s0nvaR5D1mT1a8ZkByHWNOGb6Vn4yi5TWhEdmyKlAG+08SA7Md6+jH+tYmMLueAwNeWvHHpeKrr6S4c4BA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -13499,6 +13507,14 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "node_modules/xmldom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -16035,6 +16051,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "dev": true
+    },
+    "@types/xmldom": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha512-bVy7s0nvaR5D1mT1a8ZkByHWNOGb6Vn4yi5TWhEdmyKlAG+08SA7Md6+jH+tYmMLueAwNeWvHHpeKrr6S4c4BA==",
       "dev": true
     },
     "@types/yargs": {
@@ -23603,6 +23625,11 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xmldom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "remix": "^1.2.3",
     "tailwindcss-radix": "^1.6.0",
     "tiny-invariant": "^1.2.0",
-    "ts-pattern": "^3.3.4"
+    "ts-pattern": "^3.3.4",
+    "xmldom": "^0.6.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^2.2.2",
@@ -74,6 +75,7 @@
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
     "@types/ua-parser-js": "^0.7.36",
+    "@types/xmldom": "^0.1.31",
     "concurrently": "^7.0.0",
     "esbuild-visualizer": "^0.3.1",
     "jest": "^27.4.7",

--- a/wrangler.toml.dev
+++ b/wrangler.toml.dev
@@ -1,0 +1,37 @@
+name = "jsonhero-io"
+type = "javascript"
+compatibility_date = "2022-02-01"
+
+account_id = "c974caaaa18255c03f1771097bade662"
+workers_dev = true
+
+kv_namespaces = [ 
+  { binding = "DOCUMENTS", id = "a90ce96eb26c4989a1232db27e864ed6" }
+]
+
+[vars]
+GRAPH_JSON_COLLECTION = "jsonhero-dev"
+
+[site]
+bucket = "./public"
+entry-point = "."
+
+[build]
+command = "npm run build:worker"
+watch_dir = "build/index.js"
+
+[build.upload]
+format="service-worker"
+
+[env.production]
+kv_namespaces = [ 
+  { binding = "DOCUMENTS", id = "a90ce96eb26c4989a1232db27e864ed6" }
+]
+
+[env.production.vars]
+GRAPH_JSON_COLLECTION = "jsonhero-prod"
+
+# Secrets
+# [SESSION_STORAGE]
+# [GRAPH_JSON_API_KEY]
+# [PEEKALINK_API_KEY]

--- a/wrangler.toml.dev
+++ b/wrangler.toml.dev
@@ -1,4 +1,3 @@
-name = "jsonhero-io"
 type = "javascript"
 compatibility_date = "2022-02-01"
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/8944795/189931018-2d319e9c-91c9-4b99-90ea-d737a4ec6fa7.mov

### **TEST CLOUDFLARE WORKER FOR THIS PR**:
https://jsonhero-io-production.kvooak.workers.dev


### **CURRENT STATE**
- Users do not have an option to use our tool if their data is in XML format instead of JSON.
- There are external libraries to parse XML to JSON that users can use to pre-process their data before using our tool, however this is a blocker of usage.
- We cannot control the quality of output of external XML-to-JSON parser libraries.

This PR aims to set the foundation to integrate XML data format into the tool seamlessly.


### **PROPOSALS**
_**New files:**_
- Added function `convertFromRawXml()` to parse XML string to JSON string.
- Added wrapper function `createFromRawXml()` to wrap the existing method `createFromRawJson()`, taking the output of `convertFromRawXml` as the input of `createFromRawJson()`.
- Added checking function `isXML()` with similar behaviour to the existing `isJSON()` to infer XML string format.
- Added tests for 3 new functions above.

_**Dependency:**_
- Added [xmldom](https://www.npmjs.com/package/xmldom) as a dependency to be able to use DOMParser() feature which is available on native jsdom environment, but not available in Node / Cloudflare environment. This is to parse XML string to a XMLDocument as pre-process.
- `xmldom` is necessary as the native `ParserDOM` does not run on CloudFlare Workers, and also at the local environment as we have this script:

`"start:worker": "miniflare --env .env --build-command \"npm run dev:worker\" --watch"`

which [simulates](https://developers.cloudflare.com/workers/get-started/quickstarts/#api-token) CloudFlare environment with `miniflare`.

_**What is not covered:**_
- This PR does not cover the use case when users upload XML files.


### **DESIRED STATE**
- Users can paste XML string directly to the input box without having to pre-process it.
- JSON viewer reflects truthfully the XML structure. If an XML tag has attributes, they are stored in `$attributes` property of the respective JSON object, as normal values are stored in `$values` property.
- Video attached.
