### PR TITLE
Fix potential undefined access of `selection`

### DIFF
--- a/app/components/CodeEditor.tsx
+++ b/app/components/CodeEditor.tsx
@@ -79,11 +79,14 @@ export function CodeEditor(opts: CodeEditorProps) {
     if (view) {
       setSelectionRef.current = true;
 
-      const lineNumber = state?.doc.lineAt(selection?.start ?? 0).number;
+      const selectionStart = selection?.start ?? defaultProps.selection.start;
+      const selectionEnd = selection?.end ?? defaultProps.selection.end;
+
+      const lineNumber = state?.doc.lineAt(selectionStart).number;
 
       const transactionSpec: TransactionSpec = {
-        selection: { anchor: selection.start, head: selection.end },
-        effects: EditorView.scrollIntoView(selection.start, {
+        selection: { anchor: selectionStart, head: selectionEnd },
+        effects: EditorView.scrollIntoView(selectionStart, {
           y: "start",
           yMargin: 100,
         }),


### PR DESCRIPTION
`selection` may be `undefined | null` when it is passed explicitly into the props.
This PR ensures that the `defaultProps` value for `selection` always apply.

Feedback is welcome!