### PR TITLE
fix: change searchbar keyboard shortcuts to control/alt

### DIFF
--- a/app/components/SideBar.tsx
+++ b/app/components/SideBar.tsx
@@ -14,11 +14,11 @@ export function SideBar() {
   return (
     <div className="side-bar flex flex-col align-center justify-between h-full p-1 bg-slate-200 transition dark:bg-slate-800">
       <ol className="relative">
-        <SidebarLink to={`/j/${doc.id}`} hotKey="cmd+1,ctrl+1">
+        <SidebarLink to={`/j/${doc.id}`} hotKey="option+1,alt+1">
           <ToolTip arrow="left">
             <Body>Column view</Body>
             <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">
-              ⌘
+              ⌥
             </ShortcutIcon>
             <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">
               1
@@ -26,11 +26,11 @@ export function SideBar() {
           </ToolTip>
           <TemplateIcon className="p-2 w-full h-full" />
         </SidebarLink>
-        <SidebarLink to={`/j/${doc.id}/editor`} hotKey="cmd+2,ctrl+2">
+        <SidebarLink to={`/j/${doc.id}/editor`} hotKey="option+2,alt+2">
           <ToolTip arrow="left">
             <Body>JSON view</Body>
             <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">
-              ⌘
+              ⌥
             </ShortcutIcon>
             <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">
               2
@@ -38,11 +38,11 @@ export function SideBar() {
           </ToolTip>
           <CodeIcon className="p-2 w-full h-full" />
         </SidebarLink>
-        <SidebarLink to={`/j/${doc.id}/tree`} hotKey="cmd+3,ctrl+3">
+        <SidebarLink to={`/j/${doc.id}/tree`} hotKey="option+3,alt+3">
           <ToolTip arrow="left">
             <Body>Tree view</Body>
             <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">
-              ⌘
+              ⌥
             </ShortcutIcon>
             <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">
               3
@@ -52,11 +52,11 @@ export function SideBar() {
         </SidebarLink>
       </ol>
       <ol>
-        <SidebarLink to={`/j/${doc.id}/terminal`} hotKey="cmd+4,ctrl+4">
+        <SidebarLink to={`/j/${doc.id}/terminal`} hotKey="option+4,alt+4">
           <ToolTip arrow="left">
             <Body>Terminal</Body>
             <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">
-              ⌘
+              ⌥
             </ShortcutIcon>
             <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">
               4


### PR DESCRIPTION
Addresses #94 by changing searchboar keyboard shortcuts to `control+n` on mac and `alt+n` on windows. Tested on both platforms with success.
(keeping in draft until tomorrow for hacktobertfest)