### PR TITLE
Feat: Add user preferences to allow custom indent/space

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -6,6 +6,7 @@ import { SquareBracketsIcon } from "./Icons/SquareBracketsIcon";
 import { Body } from "./Primitives/Body";
 import { ThemeModeToggler } from "./ThemeModeToggle";
 import { GithubStarSmall } from "./UI/GithubStarSmall";
+import {IndentPreference} from '~/components/IndentPreference'
 
 export function Footer() {
   const { minimal } = useJsonDoc();
@@ -45,6 +46,9 @@ export function Footer() {
             <GithubStarSmall />
           </li>
         )}
+        <li>
+          <IndentPreference />
+        </li>
         <li>
           <ThemeModeToggler />
         </li>

--- a/app/components/IndentPreference.tsx
+++ b/app/components/IndentPreference.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {Body} from './Primitives/Body';
+import {usePreferences} from '~/components/PreferencesProvider';
+
+const MIN_INDENT = 1;
+const MAX_INDENT = 8;
+
+export function IndentPreference() {
+  const [preferences, setPreferences] = usePreferences();
+
+  const updatePreferences = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let newIdent = Number(e.target.value);
+    if (newIdent < MIN_INDENT) newIdent = MIN_INDENT;
+    if (newIdent > MAX_INDENT) newIdent = MAX_INDENT;
+    e.target.value = newIdent.toString();
+    setPreferences({...preferences, indent: newIdent});
+  };
+
+  return (
+    <div className="flex items-center">
+      <label className="pr-2 text-slate-800 transition dark:text-white" htmlFor="indent">
+        <Body>Indent</Body>
+      </label>
+      <input
+        type="number"
+        className="py-0 pr-0 pl-1 w-9 rounded-sm bg-slate-300 transition hover:bg-slate-400 hover:bg-opacity-50 dark:bg-slate-800 dark:text-slate-400 hover:cursor-pointer hover:dark:bg-slate-700 hover:dark:bg-opacity-70"
+        defaultValue={preferences?.indent}
+        min={MIN_INDENT} max={MAX_INDENT}
+        onChange={updatePreferences}/>
+    </div>
+  );
+}

--- a/app/components/JsonEditor.tsx
+++ b/app/components/JsonEditor.tsx
@@ -8,15 +8,17 @@ import {
 import { ViewUpdate } from "@uiw/react-codemirror";
 import jsonMap from "json-source-map";
 import { JSONHeroPath } from "@jsonhero/path";
+import {usePreferences} from '~/components/PreferencesProvider'
 
 export function JsonEditor() {
   const [json] = useJson();
   const { selectedNodeId } = useJsonColumnViewState();
   const { goToNodeId } = useJsonColumnViewAPI();
+  const [preferences] = usePreferences();
 
   const jsonMapped = useMemo(() => {
-    return jsonMap.stringify(json, null, 2);
-  }, [json]);
+    return jsonMap.stringify(json, null, preferences?.indent || 2);
+  }, [json, preferences]);
 
   const selection = useMemo<{ start: number; end: number } | undefined>(() => {
     if (!selectedNodeId) {

--- a/app/components/JsonPreview.tsx
+++ b/app/components/JsonPreview.tsx
@@ -15,6 +15,7 @@ import { getPreviewSetup } from "~/utilities/codeMirrorSetup";
 import { lightTheme, darkTheme } from "~/utilities/codeMirrorTheme";
 import { CopyTextButton } from "./CopyTextButton";
 import { useTheme } from "./ThemeProvider";
+import {usePreferences} from '~/components/PreferencesProvider'
 
 export type JsonPreviewProps = {
   json: unknown;
@@ -23,10 +24,11 @@ export type JsonPreviewProps = {
 
 export function JsonPreview({ json, highlightPath }: JsonPreviewProps) {
   const editor = useRef(null);
+  const [preferences] = usePreferences();
 
   const jsonMapped = useMemo(() => {
-    return jsonMap.stringify(json, null, 2);
-  }, [json]);
+    return jsonMap.stringify(json, null, preferences?.indent || 2);
+  }, [json, preferences]);
 
   const lines: LineRange | undefined = useMemo(() => {
     if (!highlightPath) {

--- a/app/components/JsonSchemaViewer.tsx
+++ b/app/components/JsonSchemaViewer.tsx
@@ -3,13 +3,18 @@ import { useMemo, useState } from "react";
 import { useJsonSchema } from "~/hooks/useJsonSchema";
 import { CodeViewer } from "./CodeViewer";
 import { CopyTextButton } from "./CopyTextButton";
+import {usePreferences} from '~/components/PreferencesProvider'
 
 export function JsonSchemaViewer({ path }: { path: string }) {
   const schema = useJsonSchema();
   const schemaPath = schemaPathFromPath(path);
   const schemaJson = schemaPath.first(schema);
   const [hovering, setHovering] = useState(false);
-  const code = useMemo(() => JSON.stringify(schemaJson, null, 2), [schemaJson]);
+  const [preferences] = usePreferences();
+
+  const code = useMemo(() => {
+    return JSON.stringify(schemaJson, null, preferences?.indent || 2);
+  }, [schemaJson, preferences]);
 
   return (
     <div

--- a/app/components/PreferencesProvider.tsx
+++ b/app/components/PreferencesProvider.tsx
@@ -1,58 +1,58 @@
-import {createContext, Dispatch, ReactNode, SetStateAction, useContext, useEffect, useState} from 'react'
+import {createContext, Dispatch, ReactNode, SetStateAction, useContext, useEffect, useState} from 'react';
 
 interface Preferences {
-    indent: number
+  indent: number;
 }
 
 const PreferencesDefaults: Preferences = {
-    indent: 2,
-}
+  indent: 2,
+};
 
 type PreferencesContextType = [
-        Preferences | undefined,
-    Dispatch<SetStateAction<Preferences | undefined>>
+  Preferences | undefined,
+  Dispatch<SetStateAction<Preferences | undefined>>
 ];
 
-const PreferencesContext = createContext<PreferencesContextType | undefined>(undefined)
+const PreferencesContext = createContext<PreferencesContextType | undefined>(undefined);
 
 const loadPreferences = (): Preferences => {
-    const savedPreferences = localStorage.getItem('preferences')
-    const parsedPreferences = JSON.parse(savedPreferences || '{}')
-    for(const [key, value] of Object.entries(PreferencesDefaults)) {
-        if (!parsedPreferences[key]) parsedPreferences[key] = value
-    }
-    return parsedPreferences
-}
-const savePreferences = (preferences: Preferences) => localStorage.setItem('preferences', JSON.stringify(preferences))
+  const savedPreferences = localStorage.getItem('preferences');
+  const parsedPreferences = JSON.parse(savedPreferences || '{}');
+  for (const [key, value] of Object.entries(PreferencesDefaults)) {
+    if (!parsedPreferences[key]) parsedPreferences[key] = value;
+  }
+  return parsedPreferences;
+};
+const savePreferences = (preferences: Preferences) => localStorage.setItem('preferences', JSON.stringify(preferences));
 
 export function PreferencesProvider({
-    children,
+  children,
 }: {
-    children: ReactNode;
+  children: ReactNode;
 }) {
-    const [preferences, setPreferences] = useState<Preferences>()
+  const [preferences, setPreferences] = useState<Preferences>();
 
-    useEffect(() => {
-        const preferences = loadPreferences()
-        setPreferences(preferences)
-    }, [])
+  useEffect(() => {
+    const preferences = loadPreferences();
+    setPreferences(preferences);
+  }, []);
 
-    useEffect(() => {
-        if(preferences === undefined) return
-        savePreferences(preferences)
-    }, [preferences])
+  useEffect(() => {
+    if (preferences === undefined) return;
+    savePreferences(preferences);
+  }, [preferences]);
 
-    return (
-        <PreferencesContext.Provider value={[preferences, setPreferences]}>
-            {children}
-        </PreferencesContext.Provider>
-    )
+  return (
+    <PreferencesContext.Provider value={[preferences, setPreferences]}>
+      {children}
+    </PreferencesContext.Provider>
+  );
 }
 
 export function usePreferences() {
-    const context = useContext(PreferencesContext)
-    if (context === undefined) {
-        throw new Error('usePreferences must be used within a PreferencesProvider')
-    }
-    return context
+  const context = useContext(PreferencesContext);
+  if (context === undefined) {
+    throw new Error('usePreferences must be used within a PreferencesProvider');
+  }
+  return context;
 }

--- a/app/components/PreferencesProvider.tsx
+++ b/app/components/PreferencesProvider.tsx
@@ -1,0 +1,58 @@
+import {createContext, Dispatch, ReactNode, SetStateAction, useContext, useEffect, useState} from 'react'
+
+interface Preferences {
+    indent: number
+}
+
+const PreferencesDefaults: Preferences = {
+    indent: 2,
+}
+
+type PreferencesContextType = [
+        Preferences | undefined,
+    Dispatch<SetStateAction<Preferences | undefined>>
+];
+
+const PreferencesContext = createContext<PreferencesContextType | undefined>(undefined)
+
+const loadPreferences = (): Preferences => {
+    const savedPreferences = localStorage.getItem('preferences')
+    const parsedPreferences = JSON.parse(savedPreferences || '{}')
+    for(const [key, value] of Object.entries(PreferencesDefaults)) {
+        if (!parsedPreferences[key]) parsedPreferences[key] = value
+    }
+    return parsedPreferences
+}
+const savePreferences = (preferences: Preferences) => localStorage.setItem('preferences', JSON.stringify(preferences))
+
+export function PreferencesProvider({
+    children,
+}: {
+    children: ReactNode;
+}) {
+    const [preferences, setPreferences] = useState<Preferences>()
+
+    useEffect(() => {
+        const preferences = loadPreferences()
+        setPreferences(preferences)
+    }, [])
+
+    useEffect(() => {
+        if(preferences === undefined) return
+        savePreferences(preferences)
+    }, [preferences])
+
+    return (
+        <PreferencesContext.Provider value={[preferences, setPreferences]}>
+            {children}
+        </PreferencesContext.Provider>
+    )
+}
+
+export function usePreferences() {
+    const context = useContext(PreferencesContext)
+    if (context === undefined) {
+        throw new Error('usePreferences must be used within a PreferencesProvider')
+    }
+    return context
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -44,6 +44,7 @@ import styles from "./tailwind.css";
 import { getThemeSession } from "./theme.server";
 import { getStarCount } from "./services/github.server";
 import { StarCountProvider } from "./components/StarCountProvider";
+import {PreferencesProvider} from '~/components/PreferencesProvider'
 
 export function links() {
   return [{ rel: "stylesheet", href: styles }];
@@ -112,9 +113,11 @@ export default function AppWithProviders() {
       specifiedTheme={theme}
       themeOverride={forceDarkMode ? "dark" : themeOverride}
     >
-      <StarCountProvider starCount={starCount}>
-        <App />
-      </StarCountProvider>
+      <PreferencesProvider>
+        <StarCountProvider starCount={starCount}>
+          <App />
+        </StarCountProvider>
+      </PreferencesProvider>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
Addresses issue #82 to allow users to set their preferred space/indent size.

**What does this pull request do?**

Adds a PreferenceProvider (React Context) that can be reused to store and persist user preferences throughout the application. It currently only supports the `indent` field for the space number. The indent can be set using a new field added beside the theme mode toggle button.

![image](https://user-images.githubusercontent.com/53674742/193532892-58a9e083-122c-42da-bebb-58bd6217b000.png)

**Why Preference instead of a specific Indent/Space Context?**

To introduce a general interface that can be extended for updates that would benefit from a persisted global user preferences object. The PreferenceProvider is designed to adapt automatically whenever a new attribute is added on the Preferences interface.

For now, only a small non-intrusive input field was added in the bottom of the main interface to allow modification of the spacing. Future additions of user preferences can benefit from a dedicated settings/preference view where this field can be migrated along with new fields.

The input field definitely requires additional tweaks to match the look-and-feel of the website but it serves it current purpose well enough.