### PR TITLE
Feat: Implement a JSON validation feature with alert message for malformed JSON submissions.

### DIFF
--- a/app/components/Home/HomeHeroSection.tsx
+++ b/app/components/Home/HomeHeroSection.tsx
@@ -4,11 +4,12 @@ import { ExtraLargeTitle } from "../Primitives/ExtraLargeTitle";
 import { SmallSubtitle } from "../Primitives/SmallSubtitle";
 
 import heroVideo from "~/assets/home/JsonHero2.mp4";
+import { JsonFormResponse } from "~/routes";
 
 const jsonHeroTitle = "JSON sucks.";
 const jsonHeroSlogan = "But we're making it better.";
 
-export function HomeHeroSection() {
+export function HomeHeroSection({formResponse}: {formResponse: JsonFormResponse}) {
   return (
     <div
       className={`flex items-stretch flex-col md:flex-row bg-[rgb(56,52,139)] lg:p-6 lg:pb-16 pt-20 lg:pt-32`}
@@ -31,7 +32,7 @@ export function HomeHeroSection() {
             staring at thousand line JSON files in your browser. With a few nice
             features to help make it not <em>the worst</em>.
           </SmallSubtitle>
-          <NewFile />
+          <NewFile formResponse={formResponse}/>
         </div>
       </div>
     </div>

--- a/app/components/NewFile.tsx
+++ b/app/components/NewFile.tsx
@@ -2,18 +2,30 @@ import { DragAndDropForm } from "./DragAndDropForm";
 import { Title } from "./Primitives/Title";
 import { SampleUrls } from "./SampleUrls";
 import { UrlForm } from "./UrlForm";
+import { JsonFormResponse } from "~/routes";
+import { useEffect, useState } from "react";
+import { Alert } from "~/components/UI/Alert";
+import { Body } from "~/components/Primitives/Body";
 
-export function NewFile() {
+export function NewFile({formResponse}: { formResponse: JsonFormResponse }) {
+  const [showAlert, setShowAlert] = useState(formResponse.malformedError);
+
+  useEffect(() => setShowAlert(formResponse.malformedError), [formResponse.key, formResponse.malformedError]);
+
   return (
-    <div>
-      <div className="mb-4">
-        <UrlForm />
-      </div>
-      <DragAndDropForm />
-
-      <div className="mt-4 pt-5">
+    <div className="flex flex-col gap-4">
+      <UrlForm/>
+      <DragAndDropForm/>
+      {showAlert && (
+        <Alert onDismiss={() => setShowAlert(false)}>
+          <Body>
+            Submitted JSON is malformed. Please check your JSON and try again.
+          </Body>
+        </Alert>
+      )}
+      <div className="pt-5">
         <Title className="mb-2 text-slate-200">No JSON? Try it out:</Title>
-        <SampleUrls />
+        <SampleUrls/>
       </div>
     </div>
   );

--- a/app/components/UI/Alert.tsx
+++ b/app/components/UI/Alert.tsx
@@ -1,0 +1,18 @@
+import { XIcon as CloseIcon } from '@heroicons/react/outline';
+import React from "react";
+
+export type AlertProps = {
+  children: React.ReactNode;
+  onDismiss?: () => void;
+}
+
+export function Alert({children, onDismiss}: AlertProps) {
+  return (
+    <div className="bg-red-100 border border-red-400 text-red-700 px-3 py-2 rounded relative" role="alert">
+      {children}
+      <span className="absolute top-0 bottom-0 right-0 px-3 flex items-center">
+        <CloseIcon className="fill-current h-4 w-4 text-red-500" role="button" onClick={onDismiss}/>
+      </span>
+    </div>
+  );
+}

--- a/app/jsonDoc.server.ts
+++ b/app/jsonDoc.server.ts
@@ -149,7 +149,7 @@ function isUrl(possibleUrl: string): boolean {
   }
 }
 
-function isJSON(possibleJson: string): boolean {
+export function isJSON(possibleJson: string): boolean {
   try {
     JSON.parse(possibleJson);
     return true;

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -7,19 +7,34 @@ import { HomeInfoBoxSection } from "~/components/Home/HomeInfoBoxSection";
 import { HomeSearchSection } from "~/components/Home/HomeSearchSection";
 import { HomeFooter } from "~/components/Home/HomeFooter";
 import { HomeApiHeroBanner } from "~/components/Home/HomeApiHeroBanner";
+import { json, LoaderFunction, useLoaderData } from "remix";
+import { commitSession, getSession } from "~/session.server";
+import { uuid } from "~/utilities/uuid";
+
+export interface JsonFormResponse {
+  key: string;
+  malformedError?: boolean;
+}
+
+export const loader: LoaderFunction = async ({request}) => {
+  const session = await getSession(request.headers.get("Cookie"));
+  const response: JsonFormResponse = {key: uuid(), malformedError: session.get("malformedError") ?? false}
+  return json(response, {headers: {"Set-Cookie": await commitSession(session)}});
+};
 
 export default function Index() {
+  const formResponse = useLoaderData<JsonFormResponse>();
   return (
     <div className="overflow-x-hidden">
-      <HomeHeader fixed={true} />
-      <HomeHeroSection />
-      <HomeApiHeroBanner />
-      <HomeInfoBoxSection />
-      <HomeEdgeCasesSection />
-      <HomeSearchSection />
-      <HomeCollaborateSection />
-      <HomeFeatureGridSection />
-      <HomeFooter />
+      <HomeHeader fixed={true}/>
+      <HomeHeroSection formResponse={formResponse}/>
+      <HomeApiHeroBanner/>
+      <HomeInfoBoxSection/>
+      <HomeEdgeCasesSection/>
+      <HomeSearchSection/>
+      <HomeCollaborateSection/>
+      <HomeFeatureGridSection/>
+      <HomeFooter/>
     </div>
   );
 }

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -1,0 +1,9 @@
+import { createCookieSessionStorage } from "remix";
+
+export const {getSession, commitSession, destroySession} =
+  createCookieSessionStorage({
+    cookie: {
+      name: "__session",
+      sameSite: "lax",
+    },
+  });

--- a/app/utilities/uuid.ts
+++ b/app/utilities/uuid.ts
@@ -1,0 +1,6 @@
+export function uuid() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    let r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
Fix #62 where there are no error message shown to the user when a malformed JSON is submitted. Instead, it shows nothing if passed as a string/URL, or the app crashes completely if an invalid file is uploaded.

**What does this PR do?**

1. Added a generic Alert component based on https://v1.tailwindcss.com/components/alerts.
2. Added a utility function to generate random UUID -> used for key generation on other components.
3. `createCookieSessionStorage` to store cookies with Remix. Needed for the session flash.
4. Implements additional validation features on the `/actions/createFrom__` routes.
   1. Validates the content of upload files, redirect to index with an flag if invalid. Before, the app just crashes.
   2. Session flash: Return data to the fallback route during failure (landing page in this case).
5. Add a Remix loader in the homepage to receive the data sent by the action routes.
6. Add an alert box in the `NewFile.tsx` to show a message if the JSON submitted to the action routes is malformed.
   1. Styling fix: Replaced explicit margin `mb-4` by setting the container to a flexbox with gap attribute specified.

This is obviously a pretty big change and I would love to hear any suggestions to make this PR better.

**Possible alternative solution**

A much more simpler route than leveraging `session flash` is just by attaching a URL parameter on the `redirect("/")` call on the action routes. It would remove the need for the additional remix and cookie what-not. But since the project already depends on Remix, I see no reason why we shouldn't take full advantage of it. 

I am uncertain if using URL parameters for this would be the best approach or whether it is reliable. I am yet to encounter a project that prefers URL parameters for this sort of communication over something like flashing. It would also lead to a bad side effect. Imagine a user loading the URL with the parameter attached maybe from a link given by someone or a cached URL. Although they haven't submitted any JSON, as long as the flag is set, the alert message would still be shown.

**Screenshots**

Alert message during failure.

![image](https://user-images.githubusercontent.com/53674742/193731401-a1f05619-85d2-4433-8671-0fc102b23f6c.png)

App crashes if the file uploaded has invalid content (fixed on this PR).

![image](https://user-images.githubusercontent.com/53674742/193731459-337a1949-2dd1-462c-9902-bc3c5e348634.png)

