### PR TITLE
Replace terminal with download pointing to raw view

### DIFF
--- a/app/components/SideBar.tsx
+++ b/app/components/SideBar.tsx
@@ -1,4 +1,4 @@
-import { TemplateIcon, CodeIcon, TerminalIcon } from "@heroicons/react/outline";
+import { TemplateIcon, CodeIcon, DownloadIcon } from "@heroicons/react/outline";
 import { TreeIcon } from "~/components/Icons/TreeIcon";
 import { useHotkeys } from "react-hotkeys-hook";
 import { Link, useLocation, useNavigate } from "remix";
@@ -52,17 +52,13 @@ export function SideBar() {
         </SidebarLink>
       </ol>
       <ol>
-        <SidebarLink to={`/j/${doc.id}/terminal`} hotKey="option+4,alt+4">
-          <ToolTip arrow="left">
-            <Body>Terminal</Body>
-            <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">
-              ⌥
-            </ShortcutIcon>
-            <ShortcutIcon className="w-[26px] h-[26px] ml-1 text-slate-700 bg-slate-200 dark:text-slate-300 dark:bg-slate-800">
-              4
-            </ShortcutIcon>
-          </ToolTip>
-          <TerminalIcon className="p-2 w-full h-full" />
+        <SidebarLink>
+          <a href={`/j/${doc.id}.json`} target="_blank">
+            <ToolTip arrow="left">
+              <Body>Download</Body>
+            </ToolTip>
+            <DownloadIcon className="p-2 w-full h-full" />
+          </a>
         </SidebarLink>
       </ol>
     </div>
@@ -95,9 +91,8 @@ function SidebarLink({
     }
   }
 
-  const href = `${to}${
-    queryParams.toString().length > 0 ? `?${queryParams.toString()}` : ""
-  }`;
+  const href = `${to}${queryParams.toString().length > 0 ? `?${queryParams.toString()}` : ""
+    }`;
 
   if (hotKey) {
     const navigate = useNavigate();


### PR DESCRIPTION
Fixes #115 

![image](https://user-images.githubusercontent.com/47393058/194767039-3aa41229-c9e0-4e5c-a624-d3b78c89f020.png)
Tooltip only has download with no shortcut

Live preview at https://json.nevus.workers.dev/