### PR TITLE
Add skeleton loader to preview section

### DIFF
--- a/app/components/Preview/Types/PreviewUri.tsx
+++ b/app/components/Preview/Types/PreviewUri.tsx
@@ -41,7 +41,9 @@ export function PreviewUri(props: PreviewUriProps) {
         </>
       ) : (
         <PreviewBox>
-          <Body>Loading…</Body>
+          <Body className="h-96 animate-pulse bg-slate-300 dark:text-slate-300 dark:bg-slate-500 flex justify-center items-center">
+            Loading…
+          </Body>
         </PreviewBox>
       )}
     </div>


### PR DESCRIPTION
Resolves #38 

This PR adds a skeleton loader to the preview section to prevent content jumping. Tailwind conveniently has a [animate-pulse](https://tailwindcss.com/docs/animation#pulse) class that simulates the look and feel of a skeleton loader so I used that instead of reaching for a third-party library.

I wasn't sure how you wanted the loader to be styled so I applied the `h-96` class since I saw that being used as the `max-height` in [PreviewImage.tsx](https://github.com/apihero-run/jsonhero-web/blob/2e2197bb075a66aa29cf0f9928b11fd1456c7a5e/app/components/Preview/Types/PreviewImage.tsx#L25) . However, I'm totally open to updating the styles to better fit what you want, and figured this would be a good starting point.

Here are some examples of what the current loader looks like in the different modes:

Light Mode            |  Dark Mode
:-------------------------:|:-------------------------:
![Screen Cast 2022-10-09 at 2 08 08 PM](https://user-images.githubusercontent.com/6391149/194773263-98ffc2b4-5467-433d-b806-cd9f7a433be4.gif)  |  ![Screen Cast 2022-10-09 at 2 08 45 PM](https://user-images.githubusercontent.com/6391149/194773317-9f9982d7-4de1-4aa3-acaf-7e193bd80de4.gif)