### PR TITLE
fix #95: App crashes on URL preview when connection is lost

### DIFF
--- a/app/components/Preview/Types/PreviewUri.tsx
+++ b/app/components/Preview/Types/PreviewUri.tsx
@@ -1,5 +1,5 @@
 import { JSONStringType } from "@jsonhero/json-infer-types/lib/@types";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useFetcher } from "remix";
 import { Body } from "~/components/Primitives/Body";
 import { PreviewBox } from "../PreviewBox";
@@ -13,12 +13,30 @@ export type PreviewUriProps = {
 
 export function PreviewUri(props: PreviewUriProps) {
   const previewFetcher = useFetcher<PreviewResult>();
-
+  const [isOffline, setIsOffline] = useState(false);
+  const listenForOnline = () => { setIsOffline(false); }
   useEffect(() => {
     const encodedUri = encodeURIComponent(props.value);
-    previewFetcher.load(`/actions/getPreview/${encodedUri}`);
+    if (window.navigator.onLine) {
+      previewFetcher.load(`/actions/getPreview/${encodedUri}`);
+    }else{
+      setIsOffline(true)
+      window.addEventListener("online", listenForOnline);
+    }
+    return () => {
+      window.removeEventListener("online", listenForOnline);
+    };
   }, [props.value]);
 
+  if(isOffline){
+    return (
+      <PreviewBox>
+        <Body>
+          unable to load preview
+        </Body>
+      </PreviewBox>
+    )
+  }
   return (
     <div>
       {previewFetcher.type === "done" ? (


### PR DESCRIPTION
closes #95 

The error is triggered by the fetch() function after calling useFetcher.load(). There doesn't seem to be an easy way to catch this error. I tried using the ErrorBoundary feature from Remix but that ended up replacing all of the columns by an error message. An alternative suggested [here](https://github.com/remix-run/remix/discussions/4242) is to use navigator.onLine to check if the user is online before making the call. I implemented that and it works well when switching the browser to offline mode.