### PR TITLE
Support English British spelling of "color" (colour)

### DIFF
--- a/app/components/Preview/Types/PreviewString.tsx
+++ b/app/components/Preview/Types/PreviewString.tsx
@@ -70,6 +70,7 @@ export function PreviewString({ info }: { info: JSONStringType }) {
       }
       return <></>;
     case "color":
+    case "colour":
       return <PreviewColor value={info.value} format={info.format} />;
     case "json":
       return <PreviewJson value={info.value} format={info.format} />;


### PR DESCRIPTION
Just to make sure all popular spellings of "color" are parsed