### PR TITLE
fix: remove dead HomeTriggerDevBanner import that breaks the lint gate

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -13,7 +13,6 @@ import {
 } from "../services/toast.server";
 import { json, useLoaderData } from "remix";
 import ToastPopover from "../components/UI/ToastPopover";
-import { HomeTriggerDevBanner } from "~/components/Home/HomeTriggerDevBanner";
 
 type LoaderData = { toastMessage?: ToastMessage };
 


### PR DESCRIPTION
## What

Removes a dangling import in `app/routes/index.tsx`:

```diff
-import { HomeTriggerDevBanner } from "~/components/Home/HomeTriggerDevBanner";
```

## Why

The `HomeTriggerDevBanner` component no longer exists in the repo (only `HomeApiHeroBanner` and `HomeGithubBanner` remain under `app/components/Home/`). The import was left behind and the symbol is **never rendered** in the page's JSX, so it is pure dead code.

Because the file is still imported, `tsc` fails on a clean checkout of `main`:

```
app/routes/index.tsx(16,38): error TS2307: Cannot find module '~/components/Home/HomeTriggerDevBanner' or its corresponding type declarations.
```

This breaks `npm run lint` — the exact gate that [CONTRIBUTING.md](https://github.com/triggerdotdev/jsonhero-web/blob/main/CONTRIBUTING.md) asks every contributor to run ("Make sure to run the `npm lint` command to ensure there are no Typescript compile-time errors"). The esbuild dev/prod bundles tree-shake the unused import, so the app itself is unaffected — only the type-check fails.

## Verification

On this branch, all gates pass:

- `npm run lint` ✅ (was failing on `main`)
- `npm test` ✅ (20/20)
- `npm run build` ✅

No behaviour change — the homepage renders identically.